### PR TITLE
Hide Button 'Berita Lainnya' on Update Harian Satgas Jabar Detail Screen

### DIFF
--- a/lib/screens/news/NewsDetailScreen.dart
+++ b/lib/screens/news/NewsDetailScreen.dart
@@ -400,7 +400,7 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
                       : Container(),
 
                   SizedBox(height: 25.0),
-                  Container(
+                  widget.id != Environment.idDailyUpdate ? Container(
                     width: MediaQuery.of(context).size.width,
                     margin: EdgeInsets.only(top: 5.0, bottom: 20.0),
                     child: OutlineButton(
@@ -417,8 +417,7 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
                         Navigator.of(context).pop(true);
                       },
                     ),
-                  ),
-//                        _latestNews(state),
+                  ) : Container(),
                   SizedBox(height: 10.0)
                 ],
               ),


### PR DESCRIPTION
Related Task:
[[S15 App] Hapus Button "Berita Lainnya" di menu Update Harian Satgas Jabar](https://trello.com/c/K26C0umC)