### PR TITLE
Add City ID to Detail Screen

### DIFF
--- a/lib/screens/selfReport/SelfReportDetailScreen.dart
+++ b/lib/screens/selfReport/SelfReportDetailScreen.dart
@@ -17,10 +17,10 @@ import 'package:pikobar_flutter/utilities/FirestoreHelper.dart';
 import 'package:pikobar_flutter/utilities/FormatDate.dart';
 
 class SelfReportDetailScreen extends StatefulWidget {
-  final String reportId, otherUID, analytics;
+  final String reportId, otherUID, analytics, cityId;
 
   SelfReportDetailScreen(
-      {Key key, this.reportId, this.otherUID, this.analytics})
+      {Key key, this.reportId, this.otherUID, this.analytics, this.cityId})
       : super(key: key);
 
   @override
@@ -129,6 +129,7 @@ class _SelfReportDetailScreenState extends State<SelfReportDetailScreen> {
                                     .push(MaterialPageRoute(
                                         builder: (context) =>
                                             SelfReportFormScreen(
+                                              cityId: widget.cityId,
                                               dailyId:
                                                   state.documentSnapshot['id'],
                                               otherUID: widget.otherUID,

--- a/lib/screens/selfReport/SelfReportList.dart
+++ b/lib/screens/selfReport/SelfReportList.dart
@@ -300,6 +300,7 @@ class _SelfReportListState extends State<SelfReportList> {
                         context,
                         MaterialPageRoute(
                             builder: (context) => SelfReportDetailScreen(
+                                cityId: widget.cityId,
                                 reportId: '${i + 1}',
                                 otherUID: widget.otherUID,
                                 analytics: widget.analytics)),
@@ -362,6 +363,7 @@ class _SelfReportListState extends State<SelfReportList> {
                     context,
                     MaterialPageRoute(
                         builder: (context) => SelfReportDetailScreen(
+                            cityId: widget.cityId,
                             reportId: '${i + 1}',
                             otherUID: widget.otherUID,
                             analytics: widget.analytics)),


### PR DESCRIPTION
- Menambahkan pesan sesuai remote config ketika mengubah lapor harian

[[S18 App] Sukses Message yang muncul ketika edit Kesehatan Harian seharusnya tetap berdasarkan city_id](https://trello.com/c/BBslgoWt/437-s18-app-sukses-message-yang-muncul-ketika-edit-kesehatan-harian-seharusnya-tetap-berdasarkan-cityid)